### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Disable dependabot updates…
+    open-pull-requests-limit: 0


### PR DESCRIPTION
# Problem

We have a lot of dependabot PR notifications in the C5 org that can drown out other notifications.

# Solution

Turn off Dependabot for repositories that have not merged the dependabot PRs in a while.

# Further steps

We could potentially archive this or other repos, or mark them as not actively maintained to let folks know we aren't keeping things up to date.
